### PR TITLE
fix 'plugins vs generators' table markdown to fix a bad rendering

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -242,8 +242,8 @@ When used by command line, Generate's CLI will then use node's `require()` syste
 
 The primary difference between "generators" and "plugins" is how they're registered, but there are a few other minor differences:
 
-|  | **Plugin** | **Generator** | 
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  | **Plugin** | **Generator** |
+| --- | --- | --- |
 | Registered with | [.use](plugins.md#use) method | [.register](#register) method or [.generator](#generator) method |
 | Instance | Loaded onto "current" `Generate` instance | A `new Generate()` instance is created for every generator registered |
 | Invoked | Immediately | `.register` deferred (lazy), `.generator` immediately |


### PR DESCRIPTION
Checkout the bottom of the following MD page: https://github.com/generate/generate/blob/master/docs/generators.md


And checkout after correction:

 https://github.com/rbecheras/generate/blob/fix-markdown-table-generators-vs-plugins/docs/generators.md
